### PR TITLE
Ported some of the OAK interfaces

### DIFF
--- a/src/Exception/IOException.php
+++ b/src/Exception/IOException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jackalope2\Exception;
+
+class IOException extends \RuntimeException
+{
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jackalope2\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException
+{
+}

--- a/src/Exception/InvalidStateException.php
+++ b/src/Exception/InvalidStateException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jackalope2\Exception;
+
+class InvalidStateException extends \RuntimeException
+{
+}

--- a/src/Exception/NumberFormatException.php
+++ b/src/Exception/NumberFormatException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jackalope2\Exception;
+
+class NumberFormatException extends \RuntimeException
+{
+}
+

--- a/src/Exception/OutOfRangeException.php
+++ b/src/Exception/OutOfRangeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jackalope2\Exception;
+
+class OutOfRangeException extends \OutOfRangeException
+{
+}
+

--- a/src/Exception/UnsupportedOperationException.php
+++ b/src/Exception/UnsupportedOperationException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jackalope2\Exception;
+
+class UnsupportedOperationException extends \RuntimeException
+{
+}
+

--- a/src/Node/State/BaseNodeStateInterface.php
+++ b/src/Node/State/BaseNodeStateInterface.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Jackalope2\Node\State;
+
+use Jackalope2\Exception\InvalidArgumentException;
+
+interface BaseNodeStateInterface
+{
+    /**
+     * Return true if the node exists
+     *
+     * @return boolean True if this node exists, False if not
+     */
+    public function exists();
+
+    /**
+     * Checks whether the named property exists. The implementation is
+     * equivalent to {@code getProperty(name) != null}, but may be optimized
+     */
+    public function getProperty($name);
+
+    /**
+     * Returns the boolean value of the named property. The implementation
+     * is equivalent to the following code, but may be optimized.
+     *
+     * <pre>
+     * PropertyState property = state.getProperty(name);
+     * return property != null
+     *     && property.getType() == Type.BOOLEAN
+     *     && property.getValue(Type.BOOLEAN);
+     * </pre>
+     *
+     * @param $name Property name
+     * @return boolean Balue of the named property, or {@code false}
+     */
+    public function getBoolean($name);
+
+    /**
+     * Returns the long value of the named property. The implementation
+     * is equivalent to the following code, but may be optimized.
+     * <pre>
+     * PropertyState property = state.getProperty(name);
+     * if (property != null && property.getType() == Type.LONG) {
+     *     return property.getValue(Type.LONG);
+     * } else {
+     *     return 0;
+     * }
+     * </pre>
+     *
+     * @param $name Property name
+     * @return int Balue of the named property, or zero
+     */
+    public function getLong($name);
+
+
+    /**
+     * Returns the string value of the named property. The implementation
+     * is equivalent to the following code, but may be optimized.
+     * <pre>
+     * PropertyState property = state.getProperty(name);
+     * if (property != null && property.getType() == Type.STRING) {
+     *     return property.getValue(Type.STRING);
+     * } else {
+     *     return null;
+     * }
+     * </pre>
+     *
+     * @param $name Property name
+     * @return string value of the named property, or {@code null}
+     */
+    public function getString($name);
+
+    /**
+     * Returns the string values of the named property. The implementation
+     * is equivalent to the following code, but may be optimized.
+     * <pre>
+     * PropertyState property = state.getProperty(name);
+     * if (property != null && property.getType() == Type.STRINGS) {
+     *     return property.getValue(Type.STRINGS);
+     * } else {
+     *     return Collections.emptyList();
+     * }
+     * </pre>
+     *
+     * @param $name property name
+     *
+     * @return string[] Values of the named property, or an empty array
+     */
+    public function getStrings($name);
+
+    /**
+     * Returns the name value of the named property. The implementation
+     * is equivalent to the following code, but may be optimized.
+     * <pre>
+     * PropertyState property = state.getProperty(name);
+     * if (property != null && property.getType() == Type.NAME) {
+     *     return property.getValue(Type.NAME);
+     * } else {
+     *     return null;
+     * }
+     * </pre>
+     *
+     * @param $name property name
+     * @return string Value of the named property, or {@code null}
+     */
+    public function getName($name);
+
+    /**
+     * Returns the name values of the named property. The implementation
+     * is equivalent to the following code, but may be optimized.
+     * <pre>
+     * PropertyState property = state.getProperty(name);
+     * if (property != null && property.getType() == Type.NAMES) {
+     *     return property.getValue(Type.NAMES);
+     * } else {
+     *     return Collections.emptyList();
+     * }
+     * </pre>
+     *
+     * @param $name property name
+     * @return string[] values of the named property, or an empty collection
+     */
+    public function getNames($name);
+
+    /**
+     * Returns the number of properties of this node.
+     *
+     * @return int Number of properties
+     */
+    public function getPropertyCount();
+
+    /**
+     * Returns an iterable of the properties of this node. Multiple
+     * iterations are guaranteed to return the properties in the same
+     * order, but the specific order used is implementation-dependent
+     * and may change across different states of the same node.
+     *
+     * @return properties in some stable order
+     */
+    public function getProperties();
+
+    /**
+     * Checks whether the named child node exists. The implementation
+     * is equivalent to {@code getChildNode(name).exists()}, except that
+     * passing an invalid name as argument will result in a {@code false}
+     * return value instead of an {@link IllegalArgumentException}.
+     *
+     * @param $name name of the child node
+     * @return {@code true} if the named child node exists,
+     *         {@code false} otherwise
+     */
+    public function hasChildNode($name);
+
+    /**
+     * Returns the named, possibly non-existent, child node. Use the
+     * {@link #exists()} method on the returned child node to determine
+     * whether the node exists or not.
+     *
+     * @param name name of the child node to return
+     * @return named child node
+     * @throws InvalidArgumentException if the given name string is is empty
+     *                                  or contains a forward slash character
+     */
+    public function getChildNode($name);
+
+    /**
+     * Returns the number of <em>iterable</em> child nodes of this node.
+     * <p>
+     * If an implementation knows the exact value, it returns it (even if
+     * the value is higher than max). If the implementation does not know the
+     * exact value, and the child node count is higher than max, it may return
+     * PHP_INT_MAX. 
+     *
+     * The cost of the operation is at most O(max).
+     * 
+     * @param $max the maximum number of entries to traverse
+     * @return number of iterable child nodes
+     */
+    public function getChildNodeCount($max);
+
+    /**
+     * Returns the names of all <em>iterable</em> child nodes.
+     *
+     * @return string[] child node names in some stable order
+     */
+    public function getChildNodeNames();
+}
+

--- a/src/Node/State/ChildNodeEntryInterface.php
+++ b/src/Node/State/ChildNodeEntryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jackalope2\Node\State;
+
+/**
+ * A {@code ChildNodeEntryInterface} instance represents the child node states of a
+ * {@link NodeStateInterface}.
+ * <h2>Equality and hash codes</h2>
+ *
+ * Two child node entries are considered equal if and only if their names
+ * and referenced node states match.
+ */
+interface ChildNodeEntryInterface
+{
+    /**
+     * The name of the child node state wrt. to its parent state.
+     *
+     * @return string name of the child node
+     */
+    public function getName();
+
+    /**
+     * The child node state
+     *
+     * @return NodeStateInterface child node state
+     */
+    public function getNodeState();
+}

--- a/src/Node/State/NodeBuilderInterface.php
+++ b/src/Node/State/NodeBuilderInterface.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Jackalope2\Node\State;
+
+use Jackalope2\Node\State\BaseNodeStateInterface;
+use Jackalope2\Exception\InvalidArgumentException;
+use Jackalope2\Node\State\NodeBuilderInterface;
+
+/**
+ * Builder interface for constructing new {@link NodeStateInterface node states}.
+ * <p>
+ * A node builder can be thought of as a mutable version of a node state.
+ * In addition to property and child node access methods like the ones that
+ * are already present in the NodeState interface, the {@code NodeBuilder}
+ * interface contains the following key methods:
+ * <ul>
+ * <li>The {@code setProperty} and {@code removeProperty} methods for
+ *     modifying properties</li>
+ * <li>The {@code getChildNode} method for accessing or modifying an existing
+ *     subtree</li>
+ * <li>The {@code setChildNode} and {@code removeChildNode} methods for adding,
+ *     replacing or removing a subtree</li>
+ * <li>The {@code exists} method for checking whether the node represented by
+ *     a builder exists or is accessible</li>
+ * <li>The {@code getNodeState} method for getting a frozen snapshot of the
+ *     modified content tree</li>
+ * </ul>
+ * All the builders acquired from the same root builder instance are linked so
+ * that changes made through one instance automatically become visible in the other
+ * builders. For example:
+ * <pre>
+ *     $rootBuilder = root.builder();
+ *     $fooBuilder = rootBuilder.getChildNode("foo");
+ *     $barBuilder = fooBuilder.getChildNode("bar");
+ *
+ *     var_dump($barByuilder->getBoolean('x')) // false
+ *     $fooBuilder->getChildNode("bar")->setProperty('x', true);
+ *     var_dump($barBuilder->getBoolean('x')) // true
+ *
+ *     var_dump($barBuilder->exists()); // true
+ *     $fooBuilder->removeChildNode("bar");
+ *     var_dump($barBuilder->exists()); // false
+ * </pre>
+ * The {@code getNodeState} method returns a frozen, immutable snapshot of the current
+ * state of the builder. Providing such a snapshot can be somewhat expensive especially
+ * if there are many changes in the builder, so the method should generally only be used
+ * as the last step after all intended changes have been made. Meanwhile the accessors
+ * in the {@code NodeBuilder} interface can be used to provide efficient read access to
+ * the current state of the tree being modified.
+ * <p>
+ * The node states constructed by a builder often retain an internal reference to the base
+ * state used by the builder. This allows common node state comparisons to perform really.
+ */
+interface NodeBuilderInterface extends BaseNodeStateInterface
+{
+    /**
+     * Returns an immutable node state that matches the current state of
+     * the builder.
+     *
+     * @return NodeStateInterface immutable node state
+     */
+    public function getNodeState();
+
+    /**
+     * Returns the original base state that this builder is modifying.
+     * The return value may be non-existent (i.e. its {@code exists} method
+     * returns {@code false}) if this builder represents a new node that
+     * didn't exist in the base content tree.
+     *
+     * @return NodeStateInterface node state, possibly non-existent
+     */
+    public function getBaseState();
+
+    /**
+     * Check whether this builder represents a new node, which is not present in the base state.
+     *
+     * @return bool {@code true} for a new node
+     */
+    public function isNew();
+
+    /**
+     * Check whether the named property is new, i.e. not present in the base state.
+     *
+     * @param $name property name
+     * @return bool {@code true} for a new property
+     */
+    public function isPropertyNew($name);
+
+    /**
+     * Check whether this builder represents a modified node, which has either modified properties
+     * or removed or added child nodes.
+     *
+     * @return bool  {@code true} for a modified node
+     */
+    public function isModified();
+
+    /**
+     * Check whether this builder represents a node that used to exist but
+     * was then replaced with other content, for example as a result of
+     * a {@link #setChildNode(String)} call.
+     *
+     * @return bool {@code true} for a replaced node
+     */
+    public function isReplaced();
+
+    /**
+     * Check whether the named property exists in the base state but is
+     * replaced with other content, for example as a result of
+     * a {@link #setProperty(PropertyState)} call.
+     *
+     * @param $name property name
+     * @return bool {@code true} for a replaced property
+     */
+    public function isPropertyReplaced($name);
+
+    /**
+     *
+     * @param $max the maximum value
+     * @return int number of child nodes
+     */
+    public function getChildNodeCount($max);
+
+    /**
+     * Returns a builder for constructing changes to the named child node.
+     * If the named child node does not already exist, a new empty child
+     * node is automatically created as the base state of the returned
+     * child builder. Otherwise the existing child node state is used
+     * as the base state of the returned builder.
+     * <p>
+     * All updates to the returned child builder will implicitly affect
+     * also this builder, as if a
+     * {@code setNode(name, childBuilder.getNodeState())} method call
+     * had been made after each update. Repeated calls to this method with
+     * the same name will return the same child builder instance until an
+     * explicit {@link #setChildNode(String, NodeState)} or
+     * {@link #remove()} call is made, at which point the link
+     * between this builder and a previously returned child builder for
+     * that child node name will get broken.
+     *
+     * @param $name name of the child node
+     * @return NodeBuilderInterface Child builder
+     * @throws InvalidArgumentException if the given name string is empty
+     *                                  or contains the forward slash character
+     */
+    public function child($name);
+
+    /**
+     * Returns a builder for constructing changes to the named child node.
+     * If the named child node does not already exist, the returned builder
+     * will refer to a non-existent node and trying to modify it will cause
+     * {@link IllegalStateException}s to be thrown.
+     *
+     * @param $name name of the child node
+     * @return NodeBuilderInterface child builder, possibly non-existent
+     * @throws InvalidArgumentException if the given name string is empty
+     *                                  or contains the forward slash character
+     */
+    public function getChildNode($name);
+
+    /**
+     * Adds the named child node and returns a builder for modifying it.
+     * Possible previous content in the named subtree is removed.
+     *
+     * If a NodeState is passed as a second argument then the subtree will
+     * be replaced with the given node state.
+     *
+     * @param $name name of the child node
+     * @return NodeBuilderInterface child builder
+     * @throws IllegalArgumentException if the given name string is empty
+     *                                  or contains the forward slash character
+     */
+    public function setChildNode($name, NodeStateInterface $nodeState = null);
+
+    /**
+     * Remove this child node from its parent.
+     *
+     * @return boolean {@code true} for existing nodes, {@code false} otherwise
+     */
+    public function remove();
+
+    /**
+     * Move this child to a new parent with a new name. When the move succeeded this
+     * builder has been moved to {@code newParent} as child {@code newName}. Otherwise neither
+     * this builder nor {@code newParent} are modified.
+     * <p>
+     * The move succeeds if both, this builder and {@code newParent} exist, there is no child with
+     * {@code newName} at {@code newParent} and {@code newParent} is not in the subtree of this
+     * builder.
+     * <p>
+     * The move fails if the this builder or {@code newParent} does not exist or if there is
+     * already a child {@code newName} at {@code newParent}.
+     * <p>
+     * For all remaining cases (e.g. moving a builder into its own subtree) it is left
+     * to the implementation whether the move succeeds or fails as long as the state of the
+     * involved builder stays consistent.
+     *
+     * @param $newParent  builder for the new parent.
+     * @param $newName  name of this child at the new parent
+     * @return boolean {@code true} on success, {@code false} otherwise
+     * @throws InvalidArgumentException if the given name string is empty
+     *                                  or contains the forward slash character
+     */
+    public function moveTo(NodeBuilderInterface $newParent, $newName);
+
+    /**
+     * Set a property state
+     *
+     * @param PropertyStateInterface  The property state to set
+     * @return NodeBuilderInterface this builder
+     * @throws InvalidArgumentException if the property name is empty
+     *                                  or contains the forward slash character
+     */
+    public function setPropertyState(PropertyStateInterface $property);
+
+    /**
+     * Set a property state
+     *
+     * @param string $name  The name of this property
+     * @param string $value  The value of this property
+     * @param int $type The type of this property. Must be one of the PHPCR\PropertyType:: constants
+     * @throws InvalidArgumentException if the type of the value is not one of the above types, or if the property name is empty or contains the forward slash character
+     * @return NodeBuilderInterface this builder
+     */
+    public function setProperty($name, $value, $type = null);
+
+    /**
+    * Remove the named property. This method has no effect if a
+    * property of the given {@code name} does not exist.
+    *
+    * @param $name  name of the property
+    */
+    public function removeProperty($name);
+
+    /**
+     * Create a blog
+     *
+     * @param stream $stream
+     *
+     * @throws IOException
+     */
+    public function createBlob($stream);
+}

--- a/src/Node/State/NodeStateInterface.php
+++ b/src/Node/State/NodeStateInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Jackalope2\Node\State;
+
+use Jackalope2\Exception\InvalidArgumentException;
+
+interface NodeStateInterface extends BaseNodeStateInterface
+{
+    /**
+     * Returns the <em>iterable</em> child node entries of this instance.
+     * Multiple iterations are guaranteed to return the child nodes in
+     * the same order, but the specific order used is implementation
+     * dependent and may change across different states of the same node.
+     * <p>
+     * <i>Note on cost and performance:</i> while it is possible to iterate over
+     * all child {@code NodeState}s with the two methods {@link
+     * #getChildNodeNames()} and {@link #getChildNode(String)}, this method is
+     * considered more efficient because an implementation can potentially
+     * perform the retrieval of the name and {@code NodeState} in one call.
+     * This results in O(n) vs. O(n log n) when iterating over the child node
+     * names and then look up the {@code NodeState} by name.
+     *
+     * @return \Iterator node entries in some stable order
+     */
+    public function getChildNodeEntries();
+
+    /**
+     * Returns a builder for constructing a new node state based on
+     * this state, i.e. starting with all the properties and child nodes
+     * of this state.
+     *
+     * @return NodeBuilderInterface Node builder based on this state
+     */
+    public function builder();
+
+    /**
+     * Compares this node state against the given base state. Any differences
+     * are reported by calling the relevant added/changed/deleted methods of
+     * the given handler.
+     *
+     * TODO: Define the behavior of this method with regards to
+     * iterability/existence of child nodes.
+     *
+     * @param NodeStateInterface $base base state
+     * @param NodeStateDiffInterface $diff handler of node state differences
+     *
+     * @return {@code true} if the full diff was performed, or
+     *         {@code false} if it was aborted as requested by the handler
+     *         (see the {@link NodeStateDiffInterface} contract for more details)
+     */
+    public function compareAgainstBaseState(NodeState base, NodeStateDiff diff);
+}

--- a/src/Node/State/NodeStoreInterface.php
+++ b/src/Node/State/NodeStoreInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jackalope2\Node\State;
+
+/**
+ * Storage abstraction for trees. At any given point in time the stored
+ * tree is rooted at a single immutable node state.
+ *
+ * This is a low-level interface that doesn't cover functionality like
+ * merging concurrent changes or rejecting new tree states based on some
+ * higher-level consistency constraints.
+ */
+interface NodeStoreInterface
+{
+    /**
+     * Returns the latest state of the tree
+     *
+     * @return NodeStateInterface
+     */
+    public function getRoot();
+
+    /**
+     * Merges the changes between the
+     * {@link NodeBuilderInterface#getBaseState() base} and
+     * {@link NodeBuilderInterface#getNodeState() head} states
+     * of the given builder to this store.
+     *
+     * @param builder the builder whose changes to apply
+     * @param commitHook the commit hook to apply while merging changes
+     * @param info commit info associated with this merge operation
+     *
+     * @return the node state resulting from the merge.
+     *
+     * @throws CommitFailedException if the merge failed
+     * @throws IllegalArgumentException if the builder is not acquired
+     */
+    public function merge(NodeBuilderInterface $nodeBuilder, CommitHookInterface $commitHook);
+}

--- a/src/Node/State/PropertyStateInterface.php
+++ b/src/Node/State/PropertyStateInterface.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Jackalope2\Node;
+
+use Jackalope2\Exception\NumberFormatException;
+use Jackalope2\Exception\UnsupportedOperationException;
+
+/**
+ *
+ * Immutable property state. A property consists of a name and a value.
+ * A value is either an atom or an array of atoms.
+ *
+ * <h2>Equality and hash codes</h2>
+ * <p>
+ * Two property states are considered equal if and only if their names and
+ * values match. The {@link Object#equals(Object)} method needs to
+ * be implemented so that it complies with this definition. And while
+ * property states are not meant for use as hash keys, the
+ * {@link Object#hashCode()} method should still be implemented according
+ * to this equality contract.
+ */
+interface PropertyState
+{
+    /**
+     * @return string the name of this property state
+     */
+    public function getName();
+
+    /**
+     * Determine whether the value is an array of atoms
+     *
+     * @return bool {@code true} if and only if the value is an array of atoms.
+     */
+    public function isArray();
+
+    /**
+     * Determine the type of this property.
+     *
+     * One of the PHPCR\PropertyType constant values
+     *
+     * @return int the type of this property
+     */
+    public function getType();
+
+    /**
+     * Value of this property.
+     * The type of the return value is determined by the target {@code type}
+     * argument. If {@code type.isArray()} is true, this method returns an
+     * {@code Iterable} of the {@link Type#getBaseType() base type} of
+     * {@code type} containing all values of this property.
+     * If the target type is not the same as the type of this property an attempt
+     * is made to convert the value to the target type. If the conversion fails an
+     * exception is thrown. The actual conversions which take place are those defined
+     * in the {@link org.apache.jackrabbit.oak.plugins.value.Conversions} class.
+     * @param $type target type
+     * @return mixed the value of this property
+     * @throws InvalidArgumentException  if {@code type} refers to an unknown type.
+     * @throws NumberFormatException  if conversion to a number failed.
+     * @throws UnsupportedOperationException  if conversion to boolean failed.
+     * @throws OutOfRangeException If the index is less than zero or otherwise does not exist
+     */
+    public function getValue($type = null, $index = null);
+
+    /**
+     * The size of the value of this property.
+     * @param $index
+     * @return size of the value (optionally at the given {@code index}).
+     * @throws OutOfRangeException If {@code index} is less than {@code 0} or
+     *         greater or equals {@code count()}.
+     */
+    public function getSize($index = null);
+
+    /**
+     * The number of values of this property. {@code 1} for atoms.
+     * @return integer number of values
+     */
+    public function count();
+}

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Jackalope2;
+
+use PHPCR\RepositoryInterface;
+use PHPCR\LoginException;
+
+class Repository implements RepositoryInterface
+{
+    private $defaultWorkspace;
+    private $nodeStore;
+
+    public function __construct(
+        $defaultWorkspace = 'default',
+        NodeStoreInterface $nodeStore
+    )
+    {
+        $this->defaultWorkspace = $defaultWorkspace;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function login(CredentialsInterface $credentials = null, $workspaceName = null)
+    {
+        if (null === $workspaceName) {
+            $workspaceName = $this->defaultWorkspace;
+        }
+
+        $this->authenticator->authenticate($credentials, $workspaceName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDescriptorKeys()
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isStandardDescriptor($key)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDescriptor($key)
+    {
+    }
+}

--- a/src/RepositoryFactory.php
+++ b/src/RepositoryFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Jackalope2;
+
+class RepositoryFactory implements RepositoryFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getRepository(array $parameters = null)
+    {
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigurationKeys()
+    {
+        return array(
+            'storage' => 'Storage backend to use',
+        );
+    }
+}

--- a/src/Security/Authentication/LoginContextInterface.php
+++ b/src/Security/Authentication/LoginContextInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jackalope2\Security\Authentication;
+
+class LoginContextInterface
+{
+
+}

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jackalope2\Tests\Unit;
+
+use Jackalope2\Repository;
+
+class RepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->credentials = $this->prophesize('PHPCR\CredentialsInterface');
+        $this->repository = new Repository();
+    }
+
+    /**
+     * It should throw an exception if the given workspace does not exist
+     * and it is not the default workspace
+     *
+     * @expectedException \PHPCR\NoSuchWorkspaceException
+     */
+    public function testThrowExceptionNotExistsAndNotDefault()
+    {
+        $this->markSkipped('Implement me');
+        $this->repository->login($this->credentials->reveal(), 'notexisting');
+    }
+
+    /**
+     * NULL workspace should be interpreted as the default workspace
+     */
+    public function testNullIsDefault()
+    {
+        $this->markSkipped('Implement me');
+    }
+}


### PR DESCRIPTION
This is just the result of a morning investing OAK. One of the bigger differences from Jackalope1/Jackrabbit seems to be that it uses immutable node represenations - `NodeState` objects. `NodeBuilder` instances are used to create new or modified instances of nodes.

It also has a `NodeStore` which represents the content tree. This interface has a `getRoot` method, as well as methods for managing merging and checkpoints.

At this stage I do not know if copying the OAK API is the way forward, but it certainly seems like an option.
